### PR TITLE
fix: correct path to main

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
       "url": "http://github.com/alexander-veit"
     }
   ],
-  "main": "./src/index.js",
+  "main": "./es/index.js",
   "unpkg": "./dist/higlass-text.js",
   "module": "./es",
   "files": [


### PR DESCRIPTION
package.json has the following line:
```
"main": "./src/index.js",
```
However, when `higlass-text` is installed via `yarn`, there is no `src` folder. 

<img width="170" alt="image" src="https://github.com/higlass/higlass-text/assets/14843470/4706a75b-9c5d-4464-99f7-e4869cbda033">

Because of this, I get an error:
```
Error: Failed to resolve entry for package "higlass-text". The package may have incorrect main/module/exports specified
 in its package.json: Failed to resolve entry for package "higlass-text". The package may have incorrect main/module
/exports specified in its package.json.
```

I believe the correct path should be `"main": "./es/index.js",`. It fixed my error when I changed it. 
